### PR TITLE
run tests in isolation

### DIFF
--- a/test/integration/asset-conflict-test.js
+++ b/test/integration/asset-conflict-test.js
@@ -1,0 +1,22 @@
+const fixtures = require('@octokit/fixtures')
+const test = require('ava')
+
+const upload = require('../../')
+
+test.only('asset conflict', async t => {
+  fixtures.mock('api.github.com/release-assets-conflict')
+
+  try {
+    await upload({
+      owner: 'octokit-fixture-org',
+      repo: 'release-assets-conflict',
+      tag: 'v1.0.0',
+      file: 'Hello, world!\n',
+      name: 'test-upload.txt',
+      label: 'test',
+      token: '0000000000000000000000000000000000000001'
+    })
+  } catch (error) {
+    t.is(error.status, 422)
+  }
+})

--- a/test/integration/asset-replace-test.js
+++ b/test/integration/asset-replace-test.js
@@ -3,17 +3,17 @@ const test = require('ava')
 
 const upload = require('../../')
 
-test('happy path', async t => {
-  const mock = fixtures.mock('api.github.com/release-assets')
-
+test.only('asset conflict with replace', async t => {
+  const mock = fixtures.mock('api.github.com/release-assets-conflict')
   const result = await upload({
     owner: 'octokit-fixture-org',
-    repo: 'release-assets',
+    repo: 'release-assets-conflict',
     tag: 'v1.0.0',
     file: 'Hello, world!\n',
     name: 'test-upload.txt',
     label: 'test',
-    token: '0000000000000000000000000000000000000001'
+    token: '0000000000000000000000000000000000000001',
+    replace: true
   }).catch(mock.explain)
 
   t.is(result.id, 1)


### PR DESCRIPTION
`ava` runs all tests in paralell, but runs different files in separate processes so states don’t interfere. In this case, loading the same mocks with

```js
fixtures.mock(api.github.com/release-assets-conflict)
```

in two different tests the wrong mocks to be used